### PR TITLE
Fix issue #6 "Mitochondrial plots in QC report not working for no…

### DIFF
--- a/src/scanpy/bin/filter/sc_cell_filter.py
+++ b/src/scanpy/bin/filter/sc_cell_filter.py
@@ -123,7 +123,7 @@ print(adata.obs.keys())
 
 def compute_percent_mito(adata):
     # mito and genes/counts cuts
-    mito_genes = adata.var_names.str.startswith('MT-')
+    mito_genes = adata.var_names.str.contains('^MT-|^mt[-:]')
     # for each cell compute fraction of counts in mito genes vs. all genes
     adata.obs['percent_mito'] = np.sum(
         adata[:, mito_genes].X, axis=1).A1 / np.sum(adata.X, axis=1).A1


### PR DESCRIPTION
…man genomes or those with gene identifiers (e.g.: EnsemblID)" for non ENSEMBL gene IDs.

Fix issue #6 "Mitochondrial plots in QC report not working for non-human genomes or those with gene identifiers (e.g.: EnsemblID)"
so genes starting with:
  - 'MT-' (Homo sapiens)
  - 'mt-' (Mus musculus)
  - 'mt:' (Drosophila melanogaster)
are considered mitochondrial genes.