### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ tenx {
 -profiles h5ad
 ```
 
-In the generated .config file, make sur the `file_paths` parameter is set with the paths to the `.h5ad` files:
+In the generated .config file, make sure the `file_paths` parameter is set with the paths to the `.h5ad` files:
 ```
 [...]
 h5ad {
@@ -352,9 +352,11 @@ h5ad {
 }
 [...]
 ```
-- The `suffix` parameter is used to infer the sample name from the file paths.
+- The `suffix` parameter is used to infer the sample name from the file paths (it is removed from the input file path to derive a sample name).
 - The `file_paths` accepts glob patterns and also comma separated paths.
 Make sure that `sc.file_converter.iff` is set to `h5ad`.
+
+Currently H5AD input is only implemented in the `h5ad_single_sample` entry point.
 
 ## Select the optimal number of principal components
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ profiles {
     singularity {
         singularity.enabled = true
         singularity.autoMounts = true
-        singularity.runOptions = '-B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
+        singularity.runOptions = '--contain -B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
     }
     vpcx {
         docker.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,8 @@ profiles {
     singularity {
         singularity.enabled = true
         singularity.autoMounts = true
-        singularity.runOptions = '--contain -B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
+        singularity.envWhitelist = 'NUMBA_CACHE_DIR="$PWD"'
+        singularity.runOptions = '--no-home -B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
     }
     vpcx {
         docker.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,8 +50,7 @@ profiles {
     singularity {
         singularity.enabled = true
         singularity.autoMounts = true
-        singularity.envWhitelist = 'NUMBA_CACHE_DIR="$PWD"'
-        singularity.runOptions = '--no-home -B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
+        singularity.runOptions = '-B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
     }
     vpcx {
         docker.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,7 +3,7 @@ manifest {
     name = 'vib-singlecell-nf/vsn-pipelines'
     description = 'A repository of pipelines for single-cell data in Nextflow DSL2'
     homePage = 'https://github.com/vib-singlecell-nf/vsn-pipelines'
-    version = '0.8.1'
+    version = '0.8.2'
     mainScript = 'main.nf'
     defaultBranch = 'master'
     nextflowVersion = '!19.12.0-edge' // with ! prefix, stop execution if current version does not match required version.
@@ -29,6 +29,11 @@ process {
         executor = 'local'
     }
 }
+
+
+includeConfig 'src/utils/conf/scope.config'
+includeConfig 'src/utils/utils.config' // utilities config
+includeConfig 'conf/generic.config'
 
 profiles {
 
@@ -175,10 +180,6 @@ profiles {
     }
 
 }
-
-includeConfig 'src/utils/conf/scope.config'
-includeConfig 'src/utils/utils.config' // utilities config
-includeConfig 'conf/generic.config'
 
 
 timeline {

--- a/src/channels/conf/h5ad.config
+++ b/src/channels/conf/h5ad.config
@@ -2,7 +2,12 @@ params {
     data {
         h5ad {
             file_paths = ''
-            suffix = ''
+            suffix = '.h5ad'
         }
     }
+    sc {
+        file_converter {
+             iff = 'h5ad'
+         }
+     }
 }

--- a/src/utils/processes/h5adToLoom.nf
+++ b/src/utils/processes/h5adToLoom.nf
@@ -34,7 +34,7 @@ process SC__H5AD_TO_FILTERED_LOOM {
 
 	container params.sc.scanpy.container
 	clusterOptions "-l nodes=1:ppn=2 -l pmem=30gb -l walltime=1:00:00 -A ${params.global.qsubaccount}"
-	publishDir "${params.global.outdir}/loom", mode: 'link', overwrite: true
+    publishDir "${params.global.outdir}/data/intermediate", mode: 'symlink', overwrite: true
 
 	input:
 		tuple val(sampleId), path(f)

--- a/src/utils/processes/h5adToLoom.nf
+++ b/src/utils/processes/h5adToLoom.nf
@@ -5,7 +5,7 @@ process SC__H5AD_TO_LOOM {
 
 	container params.sc.scanpy.container
 	clusterOptions "-l nodes=1:ppn=2 -l pmem=30gb -l walltime=1:00:00 -A ${params.global.qsubaccount}"
-	publishDir "${params.global.outdir}/loom", mode: 'link', overwrite: true
+    publishDir "${params.global.outdir}/loom", mode: 'link', overwrite: true, saveAs: { filename -> "${params.global.project_name}.${sampleId}.SCope_output.loom" }
 
 	input:
 		// Expects:

--- a/src/utils/processes/utils.nf
+++ b/src/utils/processes/utils.nf
@@ -175,7 +175,7 @@ process COMPRESS_HDF5() {
 
 	container "aertslab/sctx-hdf5:1.10.5-r2"
 	clusterOptions "-l nodes=1:ppn=2 -l pmem=30gb -l walltime=1:00:00 -A ${params.global.qsubaccount}"
-	publishDir "${params.global.outdir}/loom", mode: 'link', overwrite: true
+	publishDir "${params.global.outdir}/data/intermediate", mode: 'symlink', overwrite: true
 
 	input:
 		tuple val(id), path(f)


### PR DESCRIPTION
Summary of changes:
* Default configuration files are now loaded **before** loading any profile-specific configs. This allows parameters in optional profiles to overwrite those set by the default profiles.
* Clarifications to the `h5ad` input profile, including setting of some default options. 
* Changes to published loom files:
  * The compressed loom file is no longer published to `out/loom/` since it's not compatible with SCope.
  * The filtered loom file (for input to SCENIC) is not longer published in `out/loom`
  * The "final" SCope-ready output loom is now named more descriptively: from `...SC__H5AD_TO_LOOM.loom`, the output file is now named: `{project_name}.{sampleId}.SCope_output.loom`
