### PR TITLE
CI updates: new test data and tests

### DIFF
--- a/.github/workflows/bbknn.yml
+++ b/.github/workflows/bbknn.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get sample data
       run: |
         mkdir testdata
-        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data.tar.gz
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_tiny.tar.gz
         tar xvf sample_data.tar.gz
         cp -r sample_data testdata/sample1
         mv sample_data testdata/sample2

--- a/.github/workflows/harmony.yml
+++ b/.github/workflows/harmony.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get sample data
       run: |
         mkdir testdata
-        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data.tar.gz
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_tiny.tar.gz
         tar xvf sample_data.tar.gz
         cp -r sample_data testdata/sample1
         mv sample_data testdata/sample2

--- a/.github/workflows/scenic_multiruns.yml
+++ b/.github/workflows/scenic_multiruns.yml
@@ -1,0 +1,30 @@
+name: scenic_multiruns
+
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Nextflow
+      run: |
+        export NXF_VER='19.12.0-edge'
+        wget -qO- get.nextflow.io | bash
+        sudo mv nextflow /usr/local/bin/
+    - name: Run scenic test
+      run: |
+        nextflow run ${GITHUB_WORKSPACE} -profile scenic_multiruns,test__scenic_multiruns,docker -entry scenic -ansi-log false
+        cat .nextflow.log
+
+

--- a/.github/workflows/single_sample.yml
+++ b/.github/workflows/single_sample.yml
@@ -24,7 +24,7 @@ jobs:
         sudo mv nextflow /usr/local/bin/
     - name: Get sample data
       run: |
-        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data.tar.gz
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_tiny.tar.gz
         tar xvf sample_data.tar.gz
     - name: Run single_sample test
       run: |

--- a/.github/workflows/single_sample_scenic.yml
+++ b/.github/workflows/single_sample_scenic.yml
@@ -24,7 +24,7 @@ jobs:
         sudo mv nextflow /usr/local/bin/
     - name: Get sample data
       run: |
-        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data.tar.gz
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_small.tar.gz
         tar xvf sample_data.tar.gz
     - name: Run single_sample_scenic test
       run: |

--- a/.github/workflows/single_sample_scenic_multiruns.yml
+++ b/.github/workflows/single_sample_scenic_multiruns.yml
@@ -1,0 +1,33 @@
+name: single_sample_scenic_multiruns
+
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Nextflow
+      run: |
+        export NXF_VER='19.12.0-edge'
+        wget -qO- get.nextflow.io | bash
+        sudo mv nextflow /usr/local/bin/
+    - name: Get sample data
+      run: |
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_small.tar.gz
+        tar xvf sample_data.tar.gz
+    - name: Run single_sample_scenic test
+      run: |
+        nextflow run ${GITHUB_WORKSPACE} -profile single_sample_scenic,scenic_multiruns,test__single_sample_scenic_multiruns,docker -entry single_sample_scenic -ansi-log false
+        cat .nextflow.log
+

--- a/conf/test__bbknn.config
+++ b/conf/test__bbknn.config
@@ -12,6 +12,17 @@ params {
         file_annotator {
             metaDataFilePath = ''
         }
+        scanpy {
+            filter {
+                cellFilterMinNGenes = 1
+            }
+            dim_reduction {
+                pca {
+                    dimReductionMethod = 'PCA'
+                    nComps = 2
+                }
+            }
+        }
     }
 }
 

--- a/conf/test__scenic.config
+++ b/conf/test__scenic.config
@@ -8,10 +8,10 @@ params {
             metaDataFilePath = ''
         }
         scenic {
-            filteredLoom = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/expr_mat.loom'
+            filteredLoom = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/expr_mat_tiny.loom'
             numWorkers = 2
             grn {
-                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/allTFs_hg38.txt'
+                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/test_TFs_tiny.txt'
             }
             cistarget {
                 motifsDb = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/genome-ranking.feather'

--- a/conf/test__scenic_multiruns.config
+++ b/conf/test__scenic_multiruns.config
@@ -1,0 +1,29 @@
+
+params {
+    global {
+        project_name = 'scenic_multiruns_CI'
+    }
+    sc {
+        file_annotator {
+            metaDataFilePath = ''
+        }
+        scenic {
+            filteredLoom = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/expr_mat_small.loom'
+            numWorkers = 2
+            grn {
+                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/test_TFs_small.txt'
+            }
+            cistarget {
+                motifsDb = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/genome-ranking.feather'
+                motifsAnnotation = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/motifs.tbl'
+                tracksDb = ''
+                tracksAnnotation = ''
+            }
+            aucell {
+                min_genes_regulon = 0
+                min_regulon_gene_occurrence = 0
+            }
+        }
+    }
+}
+

--- a/conf/test__single_sample.config
+++ b/conf/test__single_sample.config
@@ -12,6 +12,17 @@ params {
         file_annotator {
             metaDataFilePath = ''
         }
+        scanpy {
+            filter {
+                cellFilterMinNGenes = 1
+            }
+            dim_reduction {
+                pca {
+                    dimReductionMethod = 'PCA'
+                    nComps = 2
+                }
+            }
+        }
     }
 }
 

--- a/conf/test__single_sample_scenic.config
+++ b/conf/test__single_sample_scenic.config
@@ -12,10 +12,21 @@ params {
         file_annotator {
             metaDataFilePath = ''
         }
+        scanpy {
+            filter {
+                cellFilterMinNGenes = 1
+            }
+            dim_reduction {
+                pca {
+                    dimReductionMethod = 'PCA'
+                    nComps = 2
+                }
+            }
+        }
         scenic {
             numWorkers = 2
             grn {
-                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/allTFs_hg38.txt'
+                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/test_TFs_small.txt'
             }
             cistarget {
                 motifsDb = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/genome-ranking.feather'

--- a/conf/test__single_sample_scenic_multiruns.config
+++ b/conf/test__single_sample_scenic_multiruns.config
@@ -1,0 +1,46 @@
+
+params {
+    global {
+        project_name = 'single_sample_scenic_multiruns_CI'
+    }
+    data {
+        tenx {
+            cellranger_outs_dir_path = 'sample_data/outs'
+        }
+    }
+    sc {
+        file_annotator {
+            metaDataFilePath = ''
+        }
+        scanpy {
+            filter {
+                cellFilterMinNGenes = 1
+            }
+            dim_reduction {
+                pca {
+                    dimReductionMethod = 'PCA'
+                    nComps = 2
+                }
+            }
+        }
+        scenic {
+            //filteredLoom = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/expr_mat_small.loom'
+            numWorkers = 2
+            grn {
+                tfs = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/test_TFs_small.txt'
+            }
+            cistarget {
+                motifsDb = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/genome-ranking.feather'
+                motifsAnnotation = 'https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/motifs.tbl'
+                tracksDb = ''
+                tracksAnnotation = ''
+            }
+            aucell {
+                min_genes_regulon = 0
+                min_regulon_gene_occurrence = 0
+            }
+        }
+    }
+}
+
+

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -101,16 +101,23 @@ This could be very resource intensive, depending on the dataset.
 .. |scenic| image:: https://github.com/vib-singlecell-nf/vsn-pipelines/workflows/scenic/badge.svg
 
 Runs the ``scenic`` workflow alone, generating a loom file with only the SCENIC results.
+Currently, the required input is a loom file (set by `params.sc.scenic.filteredLoom`).
 
 |SCENIC Workflow|
 
 .. |SCENIC Workflow| image:: https://raw.githubusercontent.com/vib-singlecell-nf/vsn-pipelines/master/assets/images/scenic.svg?sanitize=true
 
 
-**scenic_multiruns**
---------------------
+**scenic_multiruns** |scenic_multiruns| |single_sample_scenic_multiruns|
+------------------------------------------------------------------------
+
+.. |scenic_multiruns| image:: https://github.com/vib-singlecell-nf/vsn-pipelines/workflows/scenic_multiruns/badge.svg
+.. |single_sample_scenic_multiruns| image:: https://github.com/vib-singlecell-nf/vsn-pipelines/workflows/single_sample_scenic_multiruns/badge.svg
 
 Runs the ``scenic`` workflow multiple times (set by ``params.sc.scenic.numRuns``), generating a loom file with the aggregated results from the multiple SCENIC runs.
+
+Note that this is not a complete entry-point itself, but a configuration option for the `scenic` module.
+Simply adding `-profile scenic_multiruns` during the config step will activate this analysis option for any of the standard entrypoints.
 
 |SCENIC Multi-runs Workflow|
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -180,6 +180,14 @@ profiles {
         includeConfig 'conf/genomes/hg38.config'
         includeConfig 'conf/test__scenic.config'
     }
+    test__scenic_multiruns {
+        includeConfig 'conf/genomes/hg38.config'
+        includeConfig 'conf/test__scenic_multiruns.config'
+    }
+    test__single_sample_scenic_multiruns {
+        includeConfig 'conf/genomes/hg38.config'
+        includeConfig 'conf/test__single_sample_scenic_multiruns.config'
+    }
     test__bbknn {
         includeConfig 'conf/test__bbknn.config'
     }


### PR DESCRIPTION
New test datasets used for CI tests:
* **tiny** and **small** have 100 cells and 200 genes each
  * **tiny** contains the genes necessary to produce output with a single regulon when run with SCENIC
  * **small** contains the genes necessary to produce output with two regulons when run with SCENIC
* This reduces run time of the CI tests (50% reduction with the SCENIC steps).
* When using the smaller datasets, some of parameters need to be adjusted:
  * `params.sc.scanpy.filter.cellFilterMinNGenes = 1`
  * `params.sc.scanpy.dim_reduction.pca.nComps = 2`

New CI tests:
* `scenic_multiruns`: runs SCENIC only, starting from a loom file
* `single_sample_scenic_multiruns`: runs the full single_sample_scenic pipeline, with 2x multiruns