### PR TITLE
Add Read the Docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sphinx:
+    configuration: docs/conf.py
+
+formats: all
+
+submodules:
+    exclude: all
+


### PR DESCRIPTION
Fixes the RTD build failing when trying to pull submodules over ssh