### PR TITLE
Feature/publishing updates

### DIFF
--- a/.github/workflows/single_sample_param_exploration.yml
+++ b/.github/workflows/single_sample_param_exploration.yml
@@ -19,7 +19,7 @@ jobs:
         submodules: true
     - name: Install Nextflow
       run: |
-        export NXF_VER='20.04.1'
+        export NXF_VER='20.10.0'
         wget -qO- get.nextflow.io | bash
         sudo mv nextflow /usr/local/bin/
     - name: Get sample data

--- a/.github/workflows/single_sample_param_exploration.yml
+++ b/.github/workflows/single_sample_param_exploration.yml
@@ -1,0 +1,33 @@
+name: single_sample_param_exploration
+
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Nextflow
+      run: |
+        export NXF_VER='20.04.1'
+        wget -qO- get.nextflow.io | bash
+        sudo mv nextflow /usr/local/bin/
+    - name: Get sample data
+      run: |
+        wget https://raw.githubusercontent.com/aertslab/SCENICprotocol/master/example/sample_data_tiny.tar.gz
+        tar xzvf sample_data_tiny.tar.gz
+    - name: Run single_sample_param_exploration test
+      run: |
+        nextflow run ${GITHUB_WORKSPACE} -profile single_sample,test__single_sample_param_exploration,test__compute_resources,docker -entry single_sample -ansi-log false
+        cat .nextflow.log
+

--- a/conf/test__single_sample_param_exploration.config
+++ b/conf/test__single_sample_param_exploration.config
@@ -1,0 +1,34 @@
+
+params {
+    global {
+        project_name = 'single_sample_param_exploration_CI'
+    }
+    data {
+        tenx {
+            cellranger_mex = 'sample_data/outs'
+        }
+    }
+    sc {
+        file_annotator {
+            metadataFilePath = ''
+        }
+        scanpy {
+            filter {
+                cellFilterMinNGenes = 1
+            }
+            neighborhood_graph {
+                nPcs = 2
+            }
+            dim_reduction {
+                pca {
+                    method = 'pca'
+                    nComps = 2
+                }
+            }
+            clustering {
+                resolutions = [0.8,1.0]
+            }
+        }
+    }
+}
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -368,6 +368,9 @@ profiles {
     test__single_sample_scrublet {
         includeConfig 'conf/test__single_sample_scrublet.config'
     }
+    test__single_sample_param_exploration {
+        includeConfig 'conf/test__single_sample_param_exploration.config'
+    }
     test__scenic {
         includeConfig 'conf/genomes/hg38.config'
         includeConfig 'conf/test__scenic.config'

--- a/src/utils/conf/base.config
+++ b/src/utils/conf/base.config
@@ -5,6 +5,7 @@ params {
             // pipelineOutputSuffix = ''
             compressionLevel = 6
             annotateWithBatchVariableName = false
+            mode = 'link'
         }
     }
     sc {

--- a/src/utils/processes/utils.nf
+++ b/src/utils/processes/utils.nf
@@ -414,11 +414,8 @@ def getPublishDir = { outDir, toolName ->
 process SC__PUBLISH_PROXY {
 
     publishDir "${params.global.outdir}/data/intermediate", \
-        mode: 'symlink', \
-        overwrite: true, \
-        saveAs: {
-            filename -> "${outputFileName}" 
-        }
+        mode: "${params.utils.publish.mode}", \
+        saveAs: { filename -> "${outputFileName}" }
 
     label 'compute_resources__minimal'
 
@@ -458,11 +455,8 @@ process SC__PUBLISH {
 
     publishDir \
         "${getPublishDir(params.global.outdir,toolName)}", \
-        mode: 'link', \
-        overwrite: true, \
-        saveAs: {
-            filename -> "${outputFileName}" 
-        }
+        mode: "${params.utils.publish.mode}", \
+        saveAs: { filename -> "${outputFileName}" }
 
     label 'compute_resources__minimal'
     

--- a/src/utils/workflows/utils.nf
+++ b/src/utils/workflows/utils.nf
@@ -12,7 +12,6 @@ include {
     isParamNull;
     COMPRESS_HDF5;
     SC__PUBLISH;
-    SC__PUBLISH_PROXY;
 } from "./../processes/utils.nf" params(params)
 
 formatsAllowed = ['h5ad', 'loom']
@@ -45,22 +44,11 @@ workflow PUBLISH {
                     isParamNull(toolName) ? 'NULL' : toolName,
                 )
             }
-
-            // Publish
-            SC__PUBLISH(
-                out.map {
-                    // if stashedParams not there, just put null 3rd arg
-                    it -> tuple(it[0], it[1], it.size() > 2 ? it[2]: null)
-                },
-                isParamNull(fileOutputSuffix) ? 'NULL' : fileOutputSuffix,
-                isParamNull(toolName) ? 'NULL' : toolName,
-                isParameterExplorationModeOn
-            )
         }
 
-        // Proxy to avoid file name collision
-        SC__PUBLISH_PROXY(
-            data.map {
+        // Publish
+        SC__PUBLISH(
+            out.map {
                 // if stashedParams not there, just put null 3rd arg
                 it -> tuple(it[0], it[1], it.size() > 2 ? it[2]: null)
             },
@@ -70,7 +58,7 @@ workflow PUBLISH {
         )
 
     emit:
-        SC__PUBLISH_PROXY.out
+        SC__PUBLISH.out
 
 }
 


### PR DESCRIPTION
Updates to the publishing system:
- Add option to change the copy mode for the PUBLISH workflow. Allows publishing across filesystems (when set to `copy`). Default value is to use hardlinks. (#265)
- Cleanup of `publish` workflow:
  - Change the `SC__PUBLISH` process to use hard links instead of copying internally. This partially addresses #258 (by avoiding making additional copies of the published file in the work directory upon each resume), but the process still does not cache.
  - The `SC__PUBLISH_PROXY` step is no longer needed and is removed. No longer need two processes to publish one file.
- Add parameter exploration CI test (tests a special case of the publish system).