### PR TITLE
Cellranger updates

### DIFF
--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -1,5 +1,4 @@
 singularity {
     enabled = true
     autoMounts = true
-    runOptions = '-B /ddn1/vol1/staging/leuven/stg_00002/,/staging/leuven/stg_00002/'
 }

--- a/conf/vsc.config
+++ b/conf/vsc.config
@@ -1,0 +1,15 @@
+params {
+    sc {
+        cellranger {
+            container = 'file:///staging/leuven/res_00001/software/vsn_containers/vibsinglecellnf-cellranger-5.0.1.img'
+        }
+    }
+}
+
+singularity {
+    enabled = true
+    autoMounts = true
+    runOptions = '--cleanenv -H $PWD -B /ddn1,/staging,/data,${VSC_SCRATCH}'
+    cacheDir = '/staging/leuven/res_00001/software/vsn_containers/'
+}
+

--- a/conf/vsc.config
+++ b/conf/vsc.config
@@ -12,4 +12,3 @@ singularity {
     runOptions = '--cleanenv -H $PWD -B /ddn1,/staging,/data,${VSC_SCRATCH}'
     cacheDir = '/staging/leuven/res_00001/software/vsn_containers/'
 }
-

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -30,9 +30,14 @@ Make sure you have the following software installed,
     - Docker_
     - Singularity_
 
+**NOTE**: Due to licensing restrictions, to use the cellranger components of VSN you must build and/or provide a container with ``cellranger`` and ``bcl2fastq2`` installed yourself.
+A sample ``Dockerfile`` can be found in ``./src/cellranger/``, you must download bcl2fastq2 from the Illumina_ website, and cellranger from the `10x Genomics`_ website yourself to build this container.
+
 .. _Nextflow: https://www.nextflow.io/
 .. _Docker: https://docs.docker.com/
 .. _Singularity: https://www.sylabs.io/singularity/
+.. _Illumina: https://emea.support.illumina.com/downloads/bcl2fastq-conversion-software-v2-20.html
+.. _`10x Genomics`: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
 
 Quick start
 ***********

--- a/nextflow.config
+++ b/nextflow.config
@@ -454,6 +454,10 @@ profiles {
         includeConfig 'conf/test__compute_resources.config'
     }
 
+    vsc {
+        includeConfig 'conf/vsc.config'
+    }
+
 }
 
 

--- a/src/cellranger/Dockerfile
+++ b/src/cellranger/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV CELLRANGER_VER 3.1.0
+ENV CELLRANGER_VER 5.0.1
 
 # Pre-downloaded files:
 # cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest

--- a/src/cellranger/conf/base.config
+++ b/src/cellranger/conf/base.config
@@ -1,7 +1,7 @@
 params {
     sc {
         cellranger {
-            container = 'vibsinglecellnf/cellranger:3.1.0'
+            container = '/path/to/cellranger/cellranger'
         }
     }
 }

--- a/src/cellranger/main.nf
+++ b/src/cellranger/main.nf
@@ -7,6 +7,9 @@ include {
     SC__CELLRANGER__MKFASTQ;
 } from './processes/mkfastq' params(params)
 include {
+    SC__CELLRANGER__PREFLIGHT;
+} from './processes/preflight' params(params)
+include {
     SC__CELLRANGER__COUNT;
 } from './processes/count' params(params)
 include {
@@ -24,6 +27,7 @@ workflow CELLRANGER {
         runFolder
         transcriptome
     main:
+        SC__CELLRANGER__PREFLIGHT()
         data = MKFASTQ(mkfastq_csv, runFolder)
 
         // Allow to combine old demultiplexed data with new data
@@ -54,6 +58,7 @@ workflow CELLRANGER {
 workflow CELLRANGER_WITH_METADATA {
 
     main:
+        SC__CELLRANGER__PREFLIGHT()
         CELLRANGER_COUNT_WITH_METADATA(file("metadata_test.tsv"))
 
     emit:

--- a/src/cellranger/processes/count.nf
+++ b/src/cellranger/processes/count.nf
@@ -29,15 +29,16 @@ def generateCellRangerCountCommandDefaults = {
 	}
 
 	_includeIntrons = null
-	if(processParams.containsKey('includeIntrons') {
+	if(processParams.containsKey('includeIntrons')) {
 		if (processParams.includeIntrons == true) {
 			_includeIntrons = true
 		} else {
 			_includeIntrons = false
 		}
 	}
-		_noBam = null
-	if(processParams.containsKey('noBam') {
+
+	_noBam = null
+	if(processParams.containsKey('noBam')) {
 		if (processParams.noBam == true) {
 			_noBam = true
 		} else {
@@ -56,7 +57,7 @@ def generateCellRangerCountCommandDefaults = {
 			${(processParams.containsKey('r2Length')) ? '--r2-length ' + processParams.r2Length: ''} \
 			${(processParams.containsKey('lanes')) ? '--lanes ' + processParams.lanes: ''} \
 			${_includeIntrons ? '--include-introns ': ''} \
-			${_noBam' ? '--no-bam ': ''} \
+			${_noBam ? '--no-bam ': ''} \
             --localcores=${task.cpus} \
             --localmem=${task.memory.toGiga()} \
 		"""

--- a/src/cellranger/processes/count.nf
+++ b/src/cellranger/processes/count.nf
@@ -28,21 +28,25 @@ def generateCellRangerCountCommandDefaults = {
 		_chemistry = processParams.chemistry
 	}
 
-	_includeIntrons = null
+	def _includeIntrons = null
 	if(processParams.containsKey('includeIntrons')) {
 		if (processParams.includeIntrons == true) {
 			_includeIntrons = true
-		} else {
+		} else if (processParams.includeIntrons == false) {
 			_includeIntrons = false
+		} else {
+			throw new Exception("includeIntrons option must be a boolean (true | false)")
 		}
 	}
 
-	_noBam = null
+	def _noBam = null
 	if(processParams.containsKey('noBam')) {
 		if (processParams.noBam == true) {
 			_noBam = true
-		} else {
+		} else if (processParams.noBam == false) {
 			_noBam = false
+		} else {
+			throw new Exception("noBam option must be a boolean (true | false)")
 		}
 	}
 	return (

--- a/src/cellranger/processes/count.nf
+++ b/src/cellranger/processes/count.nf
@@ -27,6 +27,23 @@ def generateCellRangerCountCommandDefaults = {
 	} else if (processParams.containsKey('chemistry')) {
 		_chemistry = processParams.chemistry
 	}
+
+	_includeIntrons = null
+	if(processParams.containsKey('includeIntrons') {
+		if (processParams.includeIntrons == true) {
+			_includeIntrons = true
+		} else {
+			_includeIntrons = false
+		}
+	}
+		_noBam = null
+	if(processParams.containsKey('noBam') {
+		if (processParams.noBam == true) {
+			_noBam = true
+		} else {
+			_noBam = false
+		}
+	}
 	return (
 		"""
 		cellranger count \
@@ -38,6 +55,8 @@ def generateCellRangerCountCommandDefaults = {
 			${(processParams.containsKey('r1Length')) ? '--r1-length ' + processParams.r1Length: ''} \
 			${(processParams.containsKey('r2Length')) ? '--r2-length ' + processParams.r2Length: ''} \
 			${(processParams.containsKey('lanes')) ? '--lanes ' + processParams.lanes: ''} \
+			${_includeIntrons ? '--include-introns ': ''} \
+			${_noBam' ? '--no-bam ': ''} \
             --localcores=${task.cpus} \
             --localmem=${task.memory.toGiga()} \
 		"""

--- a/src/cellranger/processes/count.nf
+++ b/src/cellranger/processes/count.nf
@@ -168,7 +168,9 @@ process SC__CELLRANGER__COUNT_WITH_LIBRARIES {
 
 		csvData = "fastqs,sample,library_type\n"
 		fastqs.eachWithIndex { fastq, ix -> 
-			csvData += "\$PWD/${fastq},${sampleNames[ix]},${assays[ix]}\n"
+			if (sampleNames[ix] != null) {
+				csvData += "\$PWD/${fastq},${sampleNames[ix]},${assays[ix]}\n"
+			}
 		}
 
 		"""

--- a/src/cellranger/processes/preflight.nf
+++ b/src/cellranger/processes/preflight.nf
@@ -1,0 +1,16 @@
+nextflow.enable.dsl=2
+
+toolParams = params.sc.cellranger
+
+process SC__CELLRANGER__PREFLIGHT {
+
+    exec:
+        if (toolParams.containsKey('container')) {
+            if (toolParams.container == '/path/to/cellranger/cellranger' || toolParams.container == '') {
+                throw new Exception("You must specify a container image for Cellranger!")
+            }   
+        } else {
+            throw new Exception("No container entry")
+        }
+        
+}

--- a/src/cellranger/workflows/cellRangerCountWithLibraries.nf
+++ b/src/cellranger/workflows/cellRangerCountWithLibraries.nf
@@ -8,6 +8,9 @@ import java.nio.file.Paths
 include {
     SC__CELLRANGER__COUNT_WITH_LIBRARIES;
 } from './../processes/count' params(params)
+include {
+    SC__CELLRANGER__PREFLIGHT;
+} from './processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 
@@ -59,7 +62,8 @@ workflow CELLRANGER_COUNT_WITH_LIBRARIES {
             )
         }
         .set { data }
-
+        
+        SC__CELLRANGER__PREFLIGHT()
         SC__CELLRANGER__COUNT_WITH_LIBRARIES( transcriptome, featureRef, data )
 
     emit:

--- a/src/cellranger/workflows/cellRangerCountWithLibraries.nf
+++ b/src/cellranger/workflows/cellRangerCountWithLibraries.nf
@@ -10,7 +10,7 @@ include {
 } from './../processes/count' params(params)
 include {
     SC__CELLRANGER__PREFLIGHT;
-} from './processes/preflight' params(params)
+} from './../processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 

--- a/src/cellranger/workflows/cellRangerCountWithMetadata.nf
+++ b/src/cellranger/workflows/cellRangerCountWithMetadata.nf
@@ -12,7 +12,7 @@ include {
 } from './../processes/count' params(params)
 include {
     SC__CELLRANGER__PREFLIGHT;
-} from './processes/preflight' params(params)
+} from './../processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 

--- a/src/cellranger/workflows/cellRangerCountWithMetadata.nf
+++ b/src/cellranger/workflows/cellRangerCountWithMetadata.nf
@@ -10,6 +10,9 @@ EMPTY_VALUES = ["n/a","n.a.","none","null"]
 include {
     SC__CELLRANGER__COUNT_WITH_METADATA;
 } from './../processes/count' params(params)
+include {
+    SC__CELLRANGER__PREFLIGHT;
+} from './processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 
@@ -66,6 +69,8 @@ workflow CELLRANGER_COUNT_WITH_METADATA {
                 }
             )
         }
+        
+        SC__CELLRANGER__PREFLIGHT()
         SC__CELLRANGER__COUNT_WITH_METADATA( transcriptome, data )
 
     emit:

--- a/src/cellranger/workflows/cellranger_libraries.nf
+++ b/src/cellranger/workflows/cellranger_libraries.nf
@@ -10,7 +10,7 @@ include {
 } from './mkfastq' params(params)
 include {
     SC__CELLRANGER__PREFLIGHT;
-} from './processes/preflight' params(params)
+} from './../processes/preflight' params(params)
 include {
     SC__CELLRANGER__COUNT_WITH_LIBRARIES
 } from './../processes/count' params(params)

--- a/src/cellranger/workflows/cellranger_libraries.nf
+++ b/src/cellranger/workflows/cellranger_libraries.nf
@@ -9,6 +9,9 @@ include {
     MKFASTQ
 } from './mkfastq' params(params)
 include {
+    SC__CELLRANGER__PREFLIGHT;
+} from './processes/preflight' params(params)
+include {
     SC__CELLRANGER__COUNT_WITH_LIBRARIES
 } from './../processes/count' params(params)
 
@@ -65,6 +68,8 @@ workflow CELLRANGER_LIBRARIES {
         .set { oldRunsData }
         
         // Run MKFASTQ on current run
+        SC__CELLRANGER__PREFLIGHT()
+
         data = MKFASTQ(mkfastq_csv, runFolder)
 
         // Get Library info for MKFASTQ run from params

--- a/src/cellranger/workflows/mkfastq.nf
+++ b/src/cellranger/workflows/mkfastq.nf
@@ -6,6 +6,9 @@ nextflow.enable.dsl=2
 include {
     SC__CELLRANGER__MKFASTQ;
 } from './../processes/mkfastq' params(params)
+include {
+    SC__CELLRANGER__PREFLIGHT;
+} from './processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 
@@ -20,6 +23,7 @@ workflow MKFASTQ {
         mkfastq_csv
         runFolder
     main:
+        SC__CELLRANGER__PREFLIGHT()
         SC__CELLRANGER__MKFASTQ(mkfastq_csv, runFolder)
         .flatMap()
         .map { fastq ->

--- a/src/cellranger/workflows/mkfastq.nf
+++ b/src/cellranger/workflows/mkfastq.nf
@@ -8,7 +8,7 @@ include {
 } from './../processes/mkfastq' params(params)
 include {
     SC__CELLRANGER__PREFLIGHT;
-} from './processes/preflight' params(params)
+} from './../processes/preflight' params(params)
 
 //////////////////////////////////////////////////////
 //  Define the workflow 


### PR DESCRIPTION
* Enables use of `--include-introns` and `--no-bam` from cellranger 5.0
* Checks for presence of cellranger container before attempting to run anything
* Add small note to dependencies about using cellranger component
* Adds VSC profile for use on the Flemish Super Computer (KUL-tier2)