### PR TITLE
[utils] Fix missing input when calling FILTER_BY_CELL_METADATA workflow

### DIFF
--- a/src/utils/workflows/filterAnnotateClean.nf
+++ b/src/utils/workflows/filterAnnotateClean.nf
@@ -35,7 +35,7 @@ workflow FILTER_AND_ANNOTATE_AND_CLEAN {
         }
         // Filter cells based on an indexed cell-based metadata table
         if(params.sc.containsKey("cell_filter")) {
-            out = FILTER_BY_CELL_METADATA( out )
+            out = FILTER_BY_CELL_METADATA( out, 'NULL' )
         }
         // Annotate cells based on an indexed cell-based metadata table
         if(params.sc.containsKey("cell_annotate")) {


### PR DESCRIPTION
Problem:
https://github.com/vib-singlecell-nf/vsn-pipelines/blob/721c42f889fc65e2efeecf7e52501ac29c924320/src/utils/workflows/filterAnnotateClean.nf#L38
should expect a second argument