### PR TITLE
Move cellranger container path to cellranger config

### DIFF
--- a/conf/vsc.config
+++ b/conf/vsc.config
@@ -1,14 +1,11 @@
-params {
-    sc {
-        cellranger {
-            container = 'file:///staging/leuven/res_00001/software/vsn_containers/vibsinglecellnf-cellranger-5.0.1.img'
-        }
-    }
-}
-
 singularity {
     enabled = true
     autoMounts = true
     runOptions = '--cleanenv -H $PWD -B /ddn1,/staging,/data,${VSC_SCRATCH}'
     cacheDir = '/staging/leuven/res_00001/software/vsn_containers/'
 }
+
+vsc {
+    enabled = true
+}
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,6 +33,9 @@ profiles {
     vpcx {
         includeConfig 'conf/vpcx.config'
     }
+    vsc {
+        includeConfig 'conf/vsc.config'
+    }
     min {
         includeConfig 'conf/min.config'
     }
@@ -462,10 +465,6 @@ profiles {
         includeConfig 'conf/test__compute_resources.config'
     }
 
-    vsc {
-        includeConfig 'conf/vsc.config'
-    }
-
 }
 
 
@@ -486,6 +485,9 @@ dag {
     file = "${params.global.outdir}/nextflow_reports/pipeline_dag.svg"
 }
 min {
+    enabled = false
+}
+vsc {
     enabled = false
 }
 

--- a/src/cellranger/conf/base.config
+++ b/src/cellranger/conf/base.config
@@ -6,6 +6,16 @@ params {
     }
 }
 
+if(vsc && vsc.enabled) {
+    params {
+        sc {
+            cellranger {
+                container = 'file:///staging/leuven/res_00001/software/vsn_containers/vibsinglecellnf-cellranger-5.0.1.img'
+            }
+        }
+    }
+}
+
 // define computing resources via process labels
 process {
     withLabel: 'compute_resources__cellranger_mkfastq' {


### PR DESCRIPTION
- Set a vsc.enabled parameter when loading the vsc profile
- Automatically use the local cellranger file when the vsc profile is active