### PR TITLE
Feature/255 freemuxlet generic inputs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -832,7 +832,7 @@ workflow cellranger_count_libraries {
 
 workflow cellranger_count_demuxlet {
     include {
-        cellranger_output_to_bam_barcodes;
+        get_bam_barcodes_from_cellranger_rna;
         DEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
     include {
@@ -862,29 +862,29 @@ workflow cellranger_count_demuxlet {
         params.sc.cellranger.count.transcriptome,
         fastq_data
     )
-    cellranger_output_to_bam_barcodes(data) |
+    get_bam_barcodes_from_cellranger_rna(data) |
         DEMUXLET
 }
 
 workflow freemuxlet {
     include {
-        cellranger_output_to_bam_barcodes;
+        data_channel_to_bam_barcodes;
         FREEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
     
     getDataChannel |
-        cellranger_output_to_bam_barcodes |
+        data_channel_to_bam_barcodes |
         FREEMUXLET
 }
 
 workflow demuxlet {
     include {
-        cellranger_output_to_bam_barcodes;
+        data_channel_to_bam_barcodes;
         DEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
 
     getDataChannel |
-        cellranger_output_to_bam_barcodes |
+        data_channel_to_bam_barcodes |
         DEMUXLET
 }
 
@@ -925,7 +925,7 @@ workflow cellranger_multi_sample_demuxlet {
         multi_sample as MULTI_SAMPLE;
     } from './workflows/multi_sample' params(params)
     include {
-        cellranger_output_to_bam_barcodes;
+        get_bam_barcodes_from_cellranger_rna;
         DEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
 
@@ -935,7 +935,7 @@ workflow cellranger_multi_sample_demuxlet {
             tuple(it[0], it[1], "10x_cellranger_mex", "h5ad")
         }
     )
-    cellranger_output_to_bam_barcodes(data) |
+    get_bam_barcodes_from_cellranger_rna(data) |
         DEMUXLET
 
 }
@@ -960,7 +960,7 @@ workflow cellranger_libraries_freemuxlet_multi_sample {
         multi_sample as MULTI_SAMPLE;
     } from './workflows/multi_sample' params(params)
     include {
-        cellranger_output_to_bam_barcodes;
+        get_bam_barcodes_from_cellranger_rna;
         FREEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
 
@@ -970,7 +970,7 @@ workflow cellranger_libraries_freemuxlet_multi_sample {
             tuple(it[0], it[1], "10x_cellranger_mex", "h5ad")
             }
     )
-    cellranger_output_to_bam_barcodes(data) |
+    get_bam_barcodes_from_cellranger_rna(data) |
         FREEMUXLET
 
 }
@@ -981,7 +981,7 @@ workflow cellranger_libraries_demuxlet_multi_sample {
         multi_sample as MULTI_SAMPLE;
     } from './workflows/multi_sample' params(params)
     include {
-        cellranger_output_to_bam_barcodes;
+        get_bam_barcodes_from_cellranger_rna;
         DEMUXLET;
     } from './src/popscle/workflows/demuxlet.nf' params(params)
 
@@ -991,7 +991,7 @@ workflow cellranger_libraries_demuxlet_multi_sample {
             tuple(it[0], it[1], "10x_cellranger_mex", "h5ad")
             }
     )
-    cellranger_output_to_bam_barcodes(data) |
+    get_bam_barcodes_from_cellranger_rna(data) |
         DEMUXLET
 }
 

--- a/src/popscle/Dockerfile
+++ b/src/popscle/Dockerfile
@@ -1,19 +1,21 @@
-FROM vibsinglecellnf/samtools:1.10
-# source: https://github.com/vib-singlecell-nf/bwamaptools/blob/master/Dockerfile.samtools
+FROM vibsinglecellnf/samtools:1.12
 
-RUN apk add --virtual build-dependencies git cmake g++ curl
+RUN echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list.d/testing.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake
 
 # Install popscle
-RUN git clone --depth 1 https://github.com/statgen/popscle.git && \
-    cd popscle && \
-    mkdir build && \
-    cd build && \
+RUN git clone --depth 1 https://github.com/statgen/popscle.git /tmp/popscle && \
+    mkdir -p /tmp/popscle/build && \
+    cd /tmp/popscle/build && \
     cmake .. && \
     make && \
-    cp /popscle/bin/popscle /usr/local/bin
+    cp /tmp/popscle/bin/popscle /usr/local/bin
 
 # install bedtools
-ENV BEDTOOLS_VERSION 2.29.2
+ENV BEDTOOLS_VERSION 2.30.0
 RUN curl -L -o /usr/local/bin/bedtools \
     https://github.com/arq5x/bedtools2/releases/download/v${BEDTOOLS_VERSION}/bedtools.static.binary && \
     chmod a+x /usr/local/bin/bedtools
@@ -22,7 +24,4 @@ RUN curl -L -o /usr/local/bin/bedtools \
 # (https://github.com/aertslab/popscle_helper_tools)
 RUN git clone --depth 1 https://github.com/aertslab/popscle_helper_tools.git /tmp/popscle_helper_tools && \
     mv /tmp/popscle_helper_tools/*sh /usr/local/bin
-
-RUN apk del build-dependencies && \
-    rm -rf /var/cache/apk/*
 

--- a/src/popscle/popscle.config
+++ b/src/popscle/popscle.config
@@ -1,7 +1,7 @@
 params {
     sc {
         popscle {
-            container = 'vibsinglecellnf/popscle:2020-06-16-fad4392'
+            container = 'vibsinglecellnf/popscle:2020-12-14-3e4a38b'
             vcf = '/path/to/vcf_file'
             barcode_tag = 'CB'
             freemuxlet {

--- a/src/popscle/popscle.config
+++ b/src/popscle/popscle.config
@@ -3,6 +3,7 @@ params {
         popscle {
             container = 'vibsinglecellnf/popscle:2020-06-16-fad4392'
             vcf = '/path/to/vcf_file'
+            barcode_tag = 'CB'
             freemuxlet {
                 nSamples = 2
             }

--- a/src/popscle/processes/demuxlet.nf
+++ b/src/popscle/processes/demuxlet.nf
@@ -5,7 +5,7 @@ binDir = !params.containsKey("test") ? "${workflow.projectDir}/src/popscle/bin/"
 process SC__POPSCLE__DEMUXLET {
 
     container params.sc.popscle.container
-    publishDir "${params.global.outdir}/data", mode: 'symlink'
+    publishDir "${params.global.outdir}/data", mode: params.utils.publish.mode
     label 'compute_resources__cpu'
 
     input:
@@ -31,7 +31,7 @@ process SC__POPSCLE__DEMUXLET {
 process SC__POPSCLE__FREEMUXLET {
 
     container params.sc.popscle.container
-    publishDir "${params.global.outdir}/data", mode: 'symlink'
+    publishDir "${params.global.outdir}/data", mode: params.utils.publish.mode
     label 'compute_resources__cpu'
 
     input:

--- a/src/popscle/processes/dsc_pileup.nf
+++ b/src/popscle/processes/dsc_pileup.nf
@@ -8,7 +8,7 @@ process SC__POPSCLE__DSC_PILEUP {
 
     container params.sc.popscle.container
     publishDir "${params.global.outdir}/data/intermediate", mode: 'symlink'
-    label 'compute_resources__cpu'
+    label 'compute_resources__cpu','compute_resources__24hqueue'
 
     input:
         tuple val(sampleId), path(f)

--- a/src/popscle/processes/dsc_pileup.nf
+++ b/src/popscle/processes/dsc_pileup.nf
@@ -21,6 +21,7 @@ process SC__POPSCLE__DSC_PILEUP {
         """
         popscle dsc-pileup \
             --sam ${f} \
+            ${toolParams?.barcode_tag ? '--tag-group ' +  toolParams.barcode_tag : ''} \
             --vcf ${vcf} \
             --out ${sampleId}_dsc-pileup
         """

--- a/src/popscle/processes/dsc_pileup.nf
+++ b/src/popscle/processes/dsc_pileup.nf
@@ -2,6 +2,8 @@ nextflow.enable.dsl=2
 
 binDir = !params.containsKey("test") ? "${workflow.projectDir}/src/popscle/bin/" : ""
 
+toolParams = params.sc.popscle
+
 process SC__POPSCLE__DSC_PILEUP {
 
     container params.sc.popscle.container
@@ -45,6 +47,8 @@ process SC__POPSCLE__PREFILTER_DSC_PILEUP {
             ${bam} \
             ${barcodes} \
             ${vcf} \
-            ${sampleId}_filtered_possorted_genome_bam.bam
+            ${sampleId}_filtered_possorted_genome_bam.bam \
+            ${toolParams?.barcode_tag ? toolParams.barcode_tag : ''}
         """
 }
+

--- a/src/popscle/workflows/demuxlet.nf
+++ b/src/popscle/workflows/demuxlet.nf
@@ -14,23 +14,85 @@ include {
 //////////////////////////////////////////////////////
 // Define the workflow
 
-workflow cellranger_output_to_bam_barcodes {
+workflow get_bam_barcodes_from_cellranger_rna {
+    take:
+        data // cellranger-rna output channel [ sampleId, path ]
+    main:
+        out = data.map{ it -> tuple(it[0],
+                                    file(it[1]+"/possorted*bam.bam"),
+                                    file(it[1]+"/filtered_*_bc_matrix/barcodes.tsv*")
+                                    ) }
+    emit:
+        out
+}
+
+workflow get_bam_barcodes_from_cellranger_atac {
+    take:
+        data // cellranger-atac output channel [ sampleId, path ]
+    main:
+        out = data.map{ it -> tuple(it[0],
+                                    file(it[1]+"/possorted*bam.bam"),
+                                    file(it[1]+"/filtered_peak_bc_matrix/barcodes.tsv*")
+                                    ) }
+    emit:
+        out
+}
+
+workflow get_bam_barcodes_from_cellranger_arc {
+    take:
+        data // cellranger-arc output channel [ sampleId, path ] // not yet implemented
+    main:
+        out = data.map{ it -> tuple(it[0],
+                                    file(it[1]+"/atac_possorted*bam.bam"),
+                                    file(it[1]+"/filtered_feature_bc_matrix/barcodes.tsv*")
+                                    ) }
+    emit:
+        out
+}
+
+
+workflow data_channel_to_bam_barcodes {
 
     take:
-        data // standard data channel [ sampleId, path, type, format]
+        data // standard data channel [ sampleId, path, type, format, group ]
 
     main:
-        out = data.map{ it -> [it[0],
-                               file(it[1]+"/possorted*bam.bam"),
-                               file(it[1]+"/filtered_*_bc_matrix/barcodes.tsv*")
-                               ] }
 
-        if(!params.containsKey('quiet')) out.view()
+        data.branch {
+              bam:     it[2] == 'bam'
+              tsv:     it[2] == 'tsv'
+              cr_rna:  it[2] == '10x_cellranger_mex_outs'
+              cr_atac: it[2] == '10x_atac_cellranger_mex_outs'
+              cr_arc:  it[2] == '10x_arc_cellranger_mex_outs'
+            }
+            .set{datab}
+
+
+        // cellranger rna:
+        data_cr_rna = get_bam_barcodes_from_cellranger_rna(datab.cr_rna)
+
+        // cellranger atac:
+        data_cr_atac = get_bam_barcodes_from_cellranger_atac(datab.cr_atac)
+
+        // cellranger rc:
+        data_cr_arc = get_bam_barcodes_from_cellranger_arc(datab.cr_arc)
+
+        // combine the bam+barcodes channels:
+        datab.bam.join(datab.tsv)
+                 .map{ it -> tuple(it[0],    // sampleId
+                                   it[1][0], // bam
+                                   it[5]     // tsv (barcodes)
+                                   ) }
+                 // combine outputs:
+                 .mix(data_cr_rna)
+                 .mix(data_cr_atac)
+                 .mix(data_cr_arc)
+                 .set{out}
 
     emit:
         out
-
 }
+
 
 workflow FREEMUXLET {
 


### PR DESCRIPTION
This allows multiple input formats for popscle (freemuxlet/demuxlet). 

When using the `getDataChannel` method to import data (specified with e.g. `-profile cellranger_mex`), the `data_channel_to_bam_barcodes` function is used, and can format any of the cellranger channels to a tuple of `(sampleId, bam, barcodes.tsv)`. 

Input with a (non-cellranger) bam and barcodes.tsv is possible by using `-profile bam,tsv`. Here, the bam and tsv channels are joined on the sampleId key. A new parameter `barcode_tag` allows specification of a different tag than the default `CB`.

When using a workflow that first runs cellranger, the cellranger outputs don't include the full set of values that `getDataChannel` produces (type, format, group), but these can be assumed and handled by the `get_bam_barcodes_from_cellranger_[rna|atac|arc]` functions.